### PR TITLE
fix compile error

### DIFF
--- a/src/jitcode.cc
+++ b/src/jitcode.cc
@@ -251,7 +251,7 @@ mrbjit_emit_code(mrb_state *mrb, mrbjit_vmstatus *status, mrbjit_code_info *coi)
     rc = mrbjit_emit_code_aux(mrb, status, code, coi);
   }
   catch(Xbyak::Error err) {
-    printf("Xbyak error %d \n", err);
+    printf("Xbyak error %d \n", int(err));
     exit(1);
   }
   if (rc == NULL && code == NULL) {


### PR DESCRIPTION
As auto-type-cast is not procedured for some reason, procedure type-cast explicitly.

```
CC    src/jitcode.cc -> build/host/src/jitcode.o
/home/bokko/workspace/mruby/mruby/src/jitcode.cc: In function ‘const void* mrbjit_emit_code(mrb_state*, mrbjit_vmstatus*, mrbjit_code_info*)’:
/home/bokko/workspace/mruby/mruby/src/jitcode.cc:254:36: error: cannot pass objects of non-trivially-copyable type ‘class Xbyak::Error’ through ‘...’
/home/bokko/workspace/mruby/mruby/src/jitcode.cc:254:36: warning: format ‘%d’ expects argument of type ‘int’, but argument 2 has type ‘Xbyak::Error’ [-Wformat]
```
## my environment
- GCC-4.7.3
- Linux Mint 15(kernel-3.8.0-31-generic amd64)
